### PR TITLE
Keep only one docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,8 @@
 version: '3'
 
 services:
-  php:
+  lib:
     image: ambientum/php:7.4-nginx
-    container_name: booking-calendar-php
+    container_name: booking-calendar-tool
     volumes:
       - .:/var/www/app
-
-  node:
-    image: node:12
-    container_name: booking-calendar-node
-    working_dir: /var/www/app
-    volumes:
-      - /var/www/app/node_modules
-      - ./:/var/www/app
-    tty: true
-


### PR DESCRIPTION
- remove unecessary node container
- `booking-calendar-tool` supports node and php